### PR TITLE
Fixed bug which stopped Loader.generate from working if there are missing directories

### DIFF
--- a/files/class.loader.php
+++ b/files/class.loader.php
@@ -188,10 +188,19 @@ class loader {
             }
 
             // store file
-            file_put_contents($php_base.$filename, $contents);
+            $this->file_force_contents($php_base.$filename, $contents);
         }
 
         return true;
+    }
+
+    function file_force_contents($dir, $contents){
+        $parts = explode('/', $dir);
+        $file = array_pop($parts);
+        $dir = '';
+        foreach($parts as $part)
+            if(!is_dir($dir .= "/$part")) mkdir($dir);
+        file_put_contents("$dir/$file", $contents);
     }
 
     private function minify_js($contents) {


### PR DESCRIPTION
Loader.generate would error on line 191, where file_put_contents() was trying to access directories which did not exist.

Unless you can think of a nicer/better way to do this. Please accept my pull request.
