### PR TITLE
Added an option to reuse the anti-CSRF key.

### DIFF
--- a/files/class.app.php
+++ b/files/class.app.php
@@ -115,7 +115,10 @@
             return $score;
         }
 
-        public function generateCSRFKey($key) {
+        public function generateCSRFKey($key, $reuseKey=false) {
+            if ($reuseKey && isset($_SESSION['csrf_' . $key]))
+                return $_SESSION['csrf_' . $key];
+            
             $token = base64_encode( openssl_random_pseudo_bytes(16));
             $_SESSION[ 'csrf_' . $key ] = $token;
             return $token;

--- a/html/forum/view.php
+++ b/html/forum/view.php
@@ -196,7 +196,7 @@
         }
         include('elements/wysiwyg.php');
 ?>
-                                <input type="hidden" value="<?=$app->generateCSRFKey("forumPost");?>" name="token">
+                                <input type="hidden" value="<?=$app->generateCSRFKey("forumPost", true);?>" name="token">
                                 <input type='submit' class='button' value='Submit'/>
                             </form>
 


### PR DESCRIPTION
This will prevent invalidating keys if the same page is visited in a different tab. It should still provide as good protection against CSRF, as the key will still unknown to anyone but the client. However, this method must NOT be for GET requests as GET would expose the key. Fixes #38.
