### PR TITLE
Fixing undefined offset 0 when there are no articles

### DIFF
--- a/files/elements/home_latest_articles.php
+++ b/files/elements/home_latest_articles.php
@@ -1,5 +1,8 @@
 <?php
     $latestNews = $app->articles->getArticles(null, 1);
+
+    if (isset($latestNews['articles'][0])):
+
     $latestNews = $latestNews['articles'][0];
 
     if (strtotime('-5 days') < strtotime($latestNews->submitted)):
@@ -29,5 +32,7 @@
 </div>
 
 <?php
+    endif;
+
     endif;
 ?>

--- a/files/elements/home_news.php
+++ b/files/elements/home_news.php
@@ -1,5 +1,8 @@
 <?php
     $latestNews = $app->articles->getArticles(0, 1);
+
+    if (isset($latestNews['articles'][0])):
+
     $latestNews = $latestNews['articles'][0];
     $latestNews->title = $app->parse($latestNews->title, false);
     $latestNews->body = $app->parse($latestNews->body);
@@ -27,3 +30,7 @@
     <p><?=$latestNews->body;?></p>
     <div class='right'><a href='<?=$latestNews->uri;?>'>Read post</a> &middot; <a href='/news'>More news</a></div>
 </div>
+
+<?php
+    endif;
+?>


### PR DESCRIPTION
When there are no articles (new user after fresh clone) getArticles return an empty array so the property article in the first position isn't set so the html shouldn't be rendered at all. The undefined offset 0 warning and subsequent errors could be seen in the error log though its effect didn't show visually in the page.
