### PR TITLE
Minor fixes: levels weren't properly loaded and empty levels list messed up nav bar.

### DIFF
--- a/files/class.levels.php
+++ b/files/class.levels.php
@@ -26,6 +26,7 @@
                     ON users_levels.user_id = :uid AND users_levels.level_id = levels.level_id
                     ORDER BY levels_groups.order ASC, `order` ASC, levels.level_id ASC');
             $st->bindValue(':uid', $uid?$uid:$this->app->user->uid);
+            $st->execute();
             $list = $st->fetchAll();
 
             if (!$uid) {

--- a/files/elements/navigation.php
+++ b/files/elements/navigation.php
@@ -33,8 +33,12 @@
                                 </li>
 <?php
         endforeach;
+        if ($lastGroup !== ''):
 ?>
                             </ul></li>
+<?php
+        endif;
+?>
                         </ul></li>
 <?php
     // endif;


### PR DESCRIPTION
Fixed some minor problems that occurred while running HackThis locally. Query execute to get levels was removed in commit f27a3f3. Resulting displaying of empty levels list resulted in one '&lt;/ul&gt;&lt;/li&gt;' too much.
