### PR TITLE
Added space to the left of message icons

### DIFF
--- a/html/files/css/main.scss
+++ b/html/files/css/main.scss
@@ -268,6 +268,7 @@ table {
         float: right;
         font-size: 1.65em;
         margin-top: -4px;
+        margin-left: 5px;
     }
 
     a {


### PR DESCRIPTION
Again, small addition, but this was the second thing that was bothering me for a while after the missing years from short dates.

Before / After:
![](http://i.imgur.com/S0RFmgO.png)![](http://i.imgur.com/tlvaMkF.png)
