### PR TITLE
Fix isPackageInstalled false positives

### DIFF
--- a/install_hackthis_ubuntu.sh
+++ b/install_hackthis_ubuntu.sh
@@ -17,7 +17,7 @@ Caption
 
 function isPackageInstalled {
 	packagePolicyOutput=`apt-cache policy $1`
-	echo $packagePolicyOutput | grep Installed > /dev/null
+	echo $packagePolicyOutput | grep -v none | grep Installed > /dev/null
 	return $?
 }
 


### PR DESCRIPTION
Current implementation of `isPackageInstalled` returns `0` for all packages regardless of their state (installed or not).

Here is the `apt-cache policy` command output for cases when package is **installed** and **not installed**

**Installed:**

```
$ apt-cache policy apache2
apache2:
  Installed: 2.4.7-1ubuntu4.1
  Candidate: 2.4.7-1ubuntu4.1
  Version table:
 *** 2.4.7-1ubuntu4.1 0
        500 http://fi.archive.ubuntu.com/ubuntu/ trusty-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu/ trusty-security/main amd64 Packages
        100 /var/lib/dpkg/status
     2.4.7-1ubuntu4 0
        500 http://fi.archive.ubuntu.com/ubuntu/ trusty/main amd64 Packages
```

**Not installed:**

```
$ apt-cache policy apache2
apache2:
  Installed: (none)
  Candidate: 2.4.7-1ubuntu4.1
  Version table:
     2.4.7-1ubuntu4.1 0
        500 http://fi.archive.ubuntu.com/ubuntu/ trusty-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu/ trusty-security/main amd64 Packages
     2.4.7-1ubuntu4 0
        500 http://fi.archive.ubuntu.com/ubuntu/ trusty/main amd64 Packages
```

As one can see text `Installed` is presented in both outputs. So, `apt-cache policy $1 | grep Installed` exit code would be the same for both cases.

As a fix for this problem I suggest to remove all lines matching `none` before looking for `Installed`.
