### PR TITLE
Fixing bug #139 - Moving from message dropdown to full view

### DIFF
--- a/html/files/js/notifications.js
+++ b/html/files/js/notifications.js
@@ -328,7 +328,7 @@ $(function() {
 
             $('<a>', {text: "Back to Inbox", class: "toggle-compose more", href: "/inbox"}).appendTo(composeHTML);
             composeHTML.append(composeForm);
-            $('<a>', {text: "Full View", class: "more", href: "/inbox/compose"}).appendTo(composeHTML);
+            $('<a>', {text: "Full View", class: "more full-view-via-storage", href: "/inbox/compose"}).appendTo(composeHTML);
 
             container.addClass('show-extra');
 
@@ -436,6 +436,20 @@ $(function() {
             } else
                 $error.text("Error sending message");
         }, 'json');
+
+    }).on('click', '.full-view-via-storage', function(e) {
+
+        // Since it's a link we don't want to prevent default
+        e.stopPropagation();
+
+        // Moving from composing in the message dropdown to full view.
+        // Save the recipients and content of the message in the local storage
+        // The data will not be sent to the server, and will be erased as soon
+        // as it's copied to the respective fields in the full view form.
+        if (window.localStorage) {
+            window.localStorage.recipients = $('#to')[0].value;
+            window.localStorage.content = $('form.send textarea')[0].value;
+        }
     });
 
     $('body').on('click', '.messages-new', function(e) {

--- a/html/inbox/index.php
+++ b/html/inbox/index.php
@@ -190,6 +190,21 @@
                 ?>
                 <input id="comment_submit" type="submit" value="Send" class="submit button right"/>
             </form>
+            <script>
+                $(document).ready(function() {
+                    // If transferred here from the message dropdown view, fill in the cached values
+                    if (window.localStorage) {
+                        if (window.localStorage.recipients) {
+                            $('#to')[0].value =  window.localStorage.recipients;
+                            window.localStorage.removeItem('recipients');
+                        }
+                        if (window.localStorage.content) {
+                            $('form textarea.editor')[0].value = window.localStorage.content;
+                            window.localStorage.removeItem('content');
+                        }
+                    }
+                });
+            </script>
 <?php
     else:
         if (isset($_GET['delete'])) {
@@ -205,3 +220,4 @@
 <?php
     require_once('footer.php');
 ?>
+


### PR DESCRIPTION
When clicking on the Full View line in the message composition dropdown I save the message recipients and content to the local storage. When the compose page finishes loading (document ready event), the local storage is checked and if there are values stored there, they are filled in the appropriate fields. Afterwards, the values are removed from the cache.
