### PR TITLE
Fixes to make local site work in ubuntu

### DIFF
--- a/files/init.php
+++ b/files/init.php
@@ -13,9 +13,9 @@
 
     // Content Security Policy
     $csp_rules = "
-        default-src 'self' https://hackthis.co.uk:8080 wss://hackthis.co.uk:8080 https://themes.googleusercontent.com https://*.facebook.com  https://fonts.gstatic.com;
-        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.googleapis.com https://*.google-analytics.com https://hackthis.co.uk:8080 https://cdnjs.cloudflare.com https://*.twitter.com https://*.api.twitter.com https://pagead2.googlesyndication.com *.newrelic.com https://www.google.com https://ssl.gstatic.com https://members.internetdefenseleague.org;
-        style-src 'self' 'unsafe-inline' https://*.googleapis.com;
+        default-src 'self' https://hackthis.co.uk:8080 wss://hackthis.co.uk:8080 https://themes.googleusercontent.com https://*.facebook.com https://fonts.gstatic.com https://hackthis-10af.kxcdn.com;
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.googleapis.com https://*.google-analytics.com https://hackthis.co.uk:8080 https://cdnjs.cloudflare.com https://*.twitter.com https://*.api.twitter.com https://pagead2.googlesyndication.com *.newrelic.com https://www.google.com https://ssl.gstatic.com https://members.internetdefenseleague.org https://hackthis-10af.kxcdn.com https://cdn.socket.io https://d3t63m1rxnixd2.cloudfront.net;
+        style-src 'self' 'unsafe-inline' https://*.googleapis.com https://hackthis-10af.kxcdn.com;
         img-src *;
         object-src 'self' https://*.youtube.com  https://*.ytimg.com;
         frame-src 'self' https://googleads.g.doubleclick.net https://*.youtube-nocookie.com https://*.vimeo.com https://kiwiirc.com https://www.google.com";

--- a/install_hackthis_ubuntu.sh
+++ b/install_hackthis_ubuntu.sh
@@ -92,7 +92,7 @@ ls README.md > /dev/null 2>&1 || {
 git_root_dir=`pwd`
 
 # Package installation
-required_packages="apache2 php5 libapache2-mod-php5 mysql-server php5-mysql"
+required_packages="apache2 php5 libapache2-mod-php5 mysql-server php5-mysql php5-ldap"
 echo Checking installed packages
 for package in $required_packages; do
 	installMissingPackages $package

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -489,7 +489,7 @@ CREATE TABLE IF NOT EXISTS mod_reports (
     `subject` varchar(64),
     `body` text,
     `visible` tinyint(1) DEFAULT 1, 
-    `time` timestamp DEFAULT CURRENT_TIMESTAMP
+    `time` timestamp DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`report_id`),
     FOREIGN KEY (`user_id`) REFERENCES users (`user_id`)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
Several problems that prevented the successful installation on the local machine for development:

1. Database schema generation was failing due to a missing comma in a table definition
2. Styles and scripts weren't being loaded because of cdns missing from CSP (Content security Policy)
3. PHP support for LDAP was missing and was added only to the Ubuntu install script. It also needs to be added to the windows installation script but I currently don't have the hardware to fix and test this on Windows).