### PR TITLE
Fix(install): Fixing 500 internal server error (Apache2 on Ubuntu)

### DIFF
--- a/install_hackthis_ubuntu.sh
+++ b/install_hackthis_ubuntu.sh
@@ -177,7 +177,6 @@ mysql -u $mysql_user $pass_clause < setup.sql
 echo -e "\t HackThis database was initialized"
 
 # Setting up directories and permissions
-
 echo Setting up directories and permissions
 mkdir -p html/files/css/min{,/light,/dark}
 chmod 777 html/files/css/min{,/light,/dark}
@@ -189,5 +188,10 @@ mkdir -p files/cache{,/twig}
 chmod 777 files/cache{,/twig}
 mkdir -p files/logs
 chmod 777 files/logs
+
+# Enabeling ModRewrite to solve RewriteEngine issue
+echo Enabeling Mod_Rewrite
+a2enmod rewrite
+service apache2 restart
 
 echo Done!


### PR DESCRIPTION
  *  Fixes: Invalid command 'RewriteEngine' #167 

If you would run the auto-install script on Ubuntu you would get a 500 internal server error.
After checking the logs I found out it was indeed caused by Mod_Rewrite not being enabled.
I added this at the very bottom, including an Apache restart to apply the changes.

Kind regards,

DOSmaster. ;P