### PR TITLE
Updated bbcode.js

### DIFF
--- a/html/files/js/bbcode.js
+++ b/html/files/js/bbcode.js
@@ -1,9 +1,5 @@
 $(function() {
-	$('pre.bbcode_code_body').each(function(i, e) {hljs.highlightBlock(e)});
-
-	$('body').on('click', '.bbcode_spoiler_head', function(e) {
-		e.preventDefault();
-
+	$('body').on('click', '.bbcode_spoiler_head', function() {
 		$(this).toggleClass('active');
 	});
 


### PR DESCRIPTION
In PM, if you have some message with the [ code ] tag, it will break all the [ spoilers ] tags and they won't open when clicking on "Show spoiler"
This problem is because of the first line of the function I deleted
If the code find any 'pre.bbcode_code_body', it breaks the whole code, messing spoiler and youtube tags