### PR TITLE
Allowing use of 'data:' for pictures

### DIFF
--- a/files/init.php
+++ b/files/init.php
@@ -16,7 +16,7 @@
         default-src 'self' https://hackthis.co.uk:8080 wss://hackthis.co.uk:8080 https://themes.googleusercontent.com https://*.facebook.com https://fonts.gstatic.com https://hackthis-10af.kxcdn.com;
         script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.googleapis.com https://*.google-analytics.com https://hackthis.co.uk:8080 https://cdnjs.cloudflare.com https://*.twitter.com https://*.api.twitter.com https://pagead2.googlesyndication.com *.newrelic.com https://www.google.com https://ssl.gstatic.com https://members.internetdefenseleague.org https://hackthis-10af.kxcdn.com https://cdn.socket.io https://d3t63m1rxnixd2.cloudfront.net;
         style-src 'self' 'unsafe-inline' https://*.googleapis.com https://hackthis-10af.kxcdn.com;
-        img-src *;
+        img-src * data:;
         object-src 'self' https://*.youtube.com  https://*.ytimg.com;
         frame-src 'self' https://googleads.g.doubleclick.net https://*.youtube-nocookie.com https://*.vimeo.com https://kiwiirc.com https://www.google.com";
     header("Content-Security-Policy: " . $csp_rules);


### PR DESCRIPTION
As we can see in console, there is a problem with a script trying to injecting a picture using 'data:' format
The script is this one : https://github.com/HackThis/hackthis.co.uk/blob/master/html/files/js/favcounter.js

The problem is from CSP rule : 'img-src *' which disallow the use of 'data:' format.
With this new rule, the script should works as he has to !