### PR TITLE
Update URL for socket.io js

### DIFF
--- a/files/init.php
+++ b/files/init.php
@@ -14,7 +14,7 @@
     // Content Security Policy
     $csp_rules = "
         default-src 'self' https://hackthis.co.uk:8080 wss://hackthis.co.uk:8080 https://themes.googleusercontent.com https://*.facebook.com https://fonts.gstatic.com https://hackthis-10af.kxcdn.com;
-        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.googleapis.com https://*.google-analytics.com https://hackthis.co.uk:8080 https://cdnjs.cloudflare.com https://*.twitter.com https://*.api.twitter.com https://pagead2.googlesyndication.com *.newrelic.com https://www.google.com https://ssl.gstatic.com https://members.internetdefenseleague.org https://hackthis-10af.kxcdn.com https://cdn.socket.io https://d3t63m1rxnixd2.cloudfront.net;
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.googleapis.com https://*.google-analytics.com https://hackthis.co.uk:8080 https://cdnjs.cloudflare.com https://*.twitter.com https://*.api.twitter.com https://pagead2.googlesyndication.com *.newrelic.com https://www.google.com https://ssl.gstatic.com https://members.internetdefenseleague.org https://hackthis-10af.kxcdn.com https://cdn-orig.socket.io https://d3t63m1rxnixd2.cloudfront.net;
         style-src 'self' 'unsafe-inline' https://*.googleapis.com https://hackthis-10af.kxcdn.com;
         img-src * data:;
         object-src 'self' https://*.youtube.com  https://*.ytimg.com;

--- a/files/page_header.php
+++ b/files/page_header.php
@@ -37,7 +37,7 @@
         <?= $minifier->load("css"); ?>
 
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-	<script src="https://cdn.socket.io/socket.io-1.2.1.js"></script>
+	<script src="https://cdn-orig.socket.io/socket.io-1.2.1.js"></script>
 <?php
     if (isset($currentLevel) && isset($currentLevel->data['code']->pos1)) {
         echo '        '.$currentLevel->data['code']->pos1."\n";


### PR DESCRIPTION
As cdn.socket.io now has a permanent redirect to cdn-orig.socket.io,
this currently fails the Content-Security-Policy.

Update Content-Security-Policy and script URL to cdn-orig.socket.io.