### PR TITLE
Apache does not allow whitespaces in Order directive

### DIFF
--- a/html/example.htaccess
+++ b/html/example.htaccess
@@ -181,7 +181,7 @@ AddDefaultCharset utf-8
 # danger when anyone has access to them.
 
 <FilesMatch "(^#.*#|\.(bak|config|dist|fla|inc|ini|log|psd|sh|sql|sw[op])|~)$">
-    Order allow, deny
+    Order allow,deny
     Deny from all
     Satisfy All
 </FilesMatch>


### PR DESCRIPTION
Whitespaces are not allowed in Order directives.

It generates the following error: 

> /var/www/vhosts/ht.com/htdocs/.htaccess: order takes one argument, 'allow,deny', 'deny,allow', or 'mutual-failure'